### PR TITLE
Extend Time validation to support time with seconds and milliseconds.

### DIFF
--- a/EdiEngine.Tests/DataElementValidationTests.cs
+++ b/EdiEngine.Tests/DataElementValidationTests.cs
@@ -61,7 +61,7 @@ namespace EdiEngine.Tests
         }
 
         [TestMethod]
-        public void Validation_OptionalDateTimeTest()
+        public void Validation_OptionalDateTest()
         {
             EAny def = new EAny()
             {
@@ -77,14 +77,6 @@ namespace EdiEngine.Tests
                 ReqDes = RequirementDesignator.Optional,
                 MinLength = 8,
                 MaxLength = 8,
-            };
-
-            EAny def3 = new EAny()
-            {
-                DataType = DataType.TM,
-                ReqDes = RequirementDesignator.Optional,
-                MinLength = 4,
-                MaxLength = 4,
             };
 
             var el = new EdiSimpleDataElement(def, "160102");
@@ -104,18 +96,87 @@ namespace EdiEngine.Tests
 
             el = new EdiSimpleDataElement(def2, "");
             Assert.IsTrue(el.IsValid(def2));
+        }
 
-            el = new EdiSimpleDataElement(def3, "1122");
-            Assert.IsTrue(el.IsValid(def3));
+        [TestMethod]
+        public void Validation_OptionalTimeTest()
+        {
+            EAny def = new EAny()
+            {
+                DataType = DataType.TM,
+                ReqDes = RequirementDesignator.Optional,
+                MinLength = 4,
+                MaxLength = 4,
+            };
 
-            el = new EdiSimpleDataElement(def3, "4567");
-            Assert.IsFalse(el.IsValid(def3));
+            EAny def2 = new EAny()
+            {
+                DataType = DataType.TM,
+                ReqDes = RequirementDesignator.Optional,
+                MinLength = 4,
+                MaxLength = 8,
+            };
 
-            el = new EdiSimpleDataElement(def3, "");
-            Assert.IsTrue(el.IsValid(def3));
+            var el = new EdiSimpleDataElement(def, "1122");
+            Assert.IsTrue(el.IsValid(def));
 
-            el = new EdiSimpleDataElement(def3, "1526");
-            Assert.IsTrue(el.IsValid(def3));
+            el = new EdiSimpleDataElement(def, "4567");
+            Assert.IsFalse(el.IsValid(def));
+
+            el = new EdiSimpleDataElement(def, "");
+            Assert.IsTrue(el.IsValid(def));
+
+            el = new EdiSimpleDataElement(def, "1526");
+            Assert.IsTrue(el.IsValid(def));
+
+            el = new EdiSimpleDataElement(def, "152605");
+            Assert.IsFalse(el.IsValid(def));
+
+            el = new EdiSimpleDataElement(def2, "0105");
+            Assert.IsTrue(el.IsValid(def2));
+
+            el = new EdiSimpleDataElement(def2, "101525");
+            Assert.IsTrue(el.IsValid(def2));
+
+            el = new EdiSimpleDataElement(def2, "1105355");
+            Assert.IsTrue(el.IsValid(def2));
+
+            el = new EdiSimpleDataElement(def2, "11053559");
+            Assert.IsTrue(el.IsValid(def2));
+
+            
+        }
+
+        [TestMethod]
+        public void Validation_MandatoryDateTimeTest()
+        {
+            EAny def = new EAny()
+            {
+                DataType = DataType.DT,
+                ReqDes = RequirementDesignator.Mandatory,
+                MinLength = 6,
+                MaxLength = 6,
+            };
+
+            EAny def2 = new EAny()
+            {
+                DataType = DataType.TM,
+                ReqDes = RequirementDesignator.Mandatory,
+                MinLength = 4,
+                MaxLength = 8,
+            };
+
+            var el = new EdiSimpleDataElement(def, "");
+            Assert.IsFalse(el.IsValid(def));
+
+            el = new EdiSimpleDataElement(def, null);
+            Assert.IsFalse(el.IsValid(def));
+
+            el = new EdiSimpleDataElement(def2, "");
+            Assert.IsFalse(el.IsValid(def2));
+
+            el = new EdiSimpleDataElement(def2, null);
+            Assert.IsFalse(el.IsValid(def2));
         }
 
         [TestMethod]

--- a/EdiEngine/Validation/DataElementValidator.cs
+++ b/EdiEngine/Validation/DataElementValidator.cs
@@ -18,8 +18,6 @@ namespace EdiEngine.Validation
             if (!string.IsNullOrEmpty(el.Val) && (el.Val.Length < definition.MinLength || el.Val.Length > definition.MaxLength))
                 return false;
 
-            DateTime dummyDt;
-
             switch (definition.DataType)
             {
                 case DataType.B:
@@ -27,8 +25,7 @@ namespace EdiEngine.Validation
                     return true;
 
                 case DataType.ID:
-                    return definition.AllowedValues.IndexOf(el.Val) >= 0 ||
-                        (definition.ReqDes == RequirementDesignator.Optional && string.IsNullOrEmpty(el.Val));
+                    return definition.AllowedValues.IndexOf(el.Val) >= 0 || IsOptional(el.Val, definition);
 
                 case DataType.N0:
                 case DataType.N1:
@@ -36,8 +33,7 @@ namespace EdiEngine.Validation
                 case DataType.N4:
                 case DataType.N6:
                     int dummyInt;
-                    return int.TryParse(el.Val, out dummyInt) ||
-                        (definition.ReqDes == RequirementDesignator.Optional && string.IsNullOrEmpty(el.Val));
+                    return int.TryParse(el.Val, out dummyInt) || IsOptional(el.Val, definition);
 
                 case DataType.R:
                 case DataType.R2:
@@ -48,33 +44,100 @@ namespace EdiEngine.Validation
                 case DataType.R8:
                 case DataType.R9:
                     decimal dummyDec;
-                    return decimal.TryParse(el.Val, out dummyDec) ||
-                        (definition.ReqDes == RequirementDesignator.Optional && string.IsNullOrEmpty(el.Val));
+                    return decimal.TryParse(el.Val, out dummyDec) || IsOptional(el.Val, definition);
 
                 case DataType.DT:
                     switch (definition.MaxLength)
                     {
                         case 6:
-                            return DateTime.TryParseExact(el.Val, "yyMMdd", CultureInfo.InvariantCulture,
-                                DateTimeStyles.None, out dummyDt) ||
-                                (definition.ReqDes == RequirementDesignator.Optional && string.IsNullOrEmpty(el.Val));
+                            return ValidateShortDate(el, definition); 
 
                         case 8:
-                            return DateTime.TryParseExact(el.Val, "yyyyMMdd", CultureInfo.InvariantCulture,
-                                DateTimeStyles.None, out dummyDt) ||
-                                (definition.ReqDes == RequirementDesignator.Optional && string.IsNullOrEmpty(el.Val));
+                            return ValidateLongDate(el, definition);
 
                         default:
                             throw new NotSupportedException($"Date validation with length {definition.MaxLength} is not implemented. {el.Type}");
                     }
 
                 case DataType.TM:
-                    return DateTime.TryParseExact(el.Val, "HHmm", CultureInfo.InvariantCulture, DateTimeStyles.None, out dummyDt) ||
-                        (definition.ReqDes == RequirementDesignator.Optional && string.IsNullOrEmpty(el.Val));
-
+                    switch (definition.MaxLength)
+                    {
+                        case 4:
+                            return ValidateShortTime(el, definition);
+                        case 8:
+                            return ValidateLongTime(el, definition);
+                        default:
+                            throw new NotSupportedException($"Time validation with length {definition.MaxLength} is not implemented. {el.Type}");
+                    }
                 default:
                     throw new NotSupportedException($"{definition.DataType} validation is not implemented. {el.Type}");
             }
         }
+
+        #region PrivateHelpers
+
+        private static bool ValidateLongDate(EdiSimpleDataElement el, MapSimpleDataElement definition)
+        {
+            if (string.IsNullOrEmpty(el.Val))
+                return IsOptional(el.Val, definition);
+
+            return el.Val.IsValidDateTimeString("yyyyMMdd");
+        }
+
+        private static bool ValidateShortDate(EdiSimpleDataElement el, MapSimpleDataElement definition)
+        {
+            if (string.IsNullOrEmpty(el.Val))
+                return IsOptional(el.Val, definition);
+
+            return el.Val.IsValidDateTimeString("yyMMdd");
+        }
+
+        private static bool ValidateShortTime(EdiSimpleDataElement el, MapSimpleDataElement definition)
+        {
+            if (string.IsNullOrEmpty(el.Val))
+                return IsOptional(el.Val, definition);
+
+            switch (el.Val.Length)
+            {
+                case 4:
+                    return el.Val.IsValidDateTimeString("HHmm");
+
+                default:
+                    throw new NotSupportedException($"Time validation with length {el.Val.Length} is not implemented. {el.Type}");
+            }
+        }
+
+        private static bool ValidateLongTime(EdiSimpleDataElement el, MapSimpleDataElement definition)
+        {
+            if (string.IsNullOrEmpty(el.Val))
+                return IsOptional(el.Val, definition);
+
+            switch (el.Val.Length)
+            {
+                case 4:
+                    return ValidateShortTime(el, definition);
+                case 5:
+                    return el.Val.IsValidDateTimeString("HHmms");
+                case 6:
+                    return el.Val.IsValidDateTimeString("HHmmss");
+                case 7:
+                    return el.Val.IsValidDateTimeString("HHmmssf");
+                case 8:
+                    return el.Val.IsValidDateTimeString("HHmmssff");
+                default:
+                    throw new NotSupportedException($"Time validation with length {el.Val.Length} is not implemented. {el.Type}");
+            }
+        }
+
+        private static bool IsValidDateTimeString(this string dateTime, string format)
+        {
+            return DateTime.TryParseExact(dateTime, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dummyDt);
+        }
+
+        private static bool IsOptional(string value, MapSimpleDataElement definition)
+        {
+            return definition.ReqDes == RequirementDesignator.Optional && string.IsNullOrEmpty(value);
+        }
+        #endregion
     }
 }

--- a/EdiEngine/Validation/DataElementValidator.cs
+++ b/EdiEngine/Validation/DataElementValidator.cs
@@ -131,7 +131,8 @@ namespace EdiEngine.Validation
 
         private static bool IsValidDateTimeString(this string dateTime, string format)
         {
-            return DateTime.TryParseExact(dateTime, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dummyDt);
+            DateTime dummyDt;
+            return DateTime.TryParseExact(dateTime, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out dummyDt);
         }
 
         private static bool IsOptional(string value, MapSimpleDataElement definition)


### PR DESCRIPTION
Resolves #15 plus slightly reorganize DataElementValidator, split optional date time test to be Date and Time tests, add new mandatory datetime test. 